### PR TITLE
Use gunzip-maybe to support .tar.gz files

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var tar = require('tar-fs')
 var unzip = require('unzip')
 var request = require('request')
 var rimraf = require('rimraf')
+var gunzip = require('gunzip-maybe')
 
 if (process.argv[2] === 'init') {
   prompt('Enter encrypted github token for travis:', function (travis) {
@@ -94,7 +95,7 @@ function download () {
             uz.end()
           })
         } else {
-          req.pipe(tar.extract('.prebuilds.tmp')).on('finish', loop)
+          req.pipe(gunzip()).pipe(tar.extract('.prebuilds.tmp')).on('finish', loop)
         }
       }
     })

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "ghreleases": "^2.0.0",
+    "gunzip-maybe": "^1.4.1",
     "package-repo": "^1.0.0",
     "request": "^2.85.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
Working on using `prebuildify` for `deltachat` here https://github.com/deltachat/deltachat-node/blob/prebuildify/scripts/prebuildify.js#L54 and we'd like to do `.tar.gz` for everything, even on windows.