### PR TITLE
Protect against partially completed CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prebuildify-ci
 
-Easily setup prebuilding of native modules using CI and [prebuildify](https://github.com/mafintosh/prebuildify)
+Easily setup prebuilding of native modules using CI and [prebuildify](https://github.com/prebuild/prebuildify)
 
 ```
 npm install -g prebuildify-ci
@@ -9,7 +9,7 @@ npm install -g prebuildify-ci
 ## Usage
 
 First create a native module and add a `prebuild` script to your npm scripts
-that prebuilds the module using [prebuildify](https://github.com/mafintosh/prebuildify).
+that prebuilds the module using [prebuildify](https://github.com/prebuild/prebuildify).
 
 An example of this can be found in the [turbo-net package](https://github.com/mafintosh/turbo-net/blob/master/package.json#L20)
 
@@ -41,8 +41,8 @@ Wait for CI to finish. Once all the builds are done run
 prebuildify-ci download
 ```
 
-This will download all the prebuilds into ./prebuilds where [node-gyp-build](https://github.com/mafintosh/node-gyp-build) will
-expect them to be stored.
+This will download all the prebuilds into ./prebuilds where [node-gyp-build](https://github.com/prebuild/node-gyp-build) will
+expect them to be stored. To optionally verify the number of expected platform-arch combinations, pass an `--expect <n>` parameter.
 
 That's it! Now you are ready to publish your tarball with the prebuilds included.
 

--- a/index.js
+++ b/index.js
@@ -9,15 +9,16 @@ var unzip = require('unzip')
 var request = require('request')
 var rimraf = require('rimraf')
 var gunzip = require('gunzip-maybe')
+var argv = require('minimist')(process.argv.slice(2))
 
-if (process.argv[2] === 'init') {
+if (argv._[0] === 'init') {
   prompt('Enter encrypted github token for travis:', function (travis) {
     prompt('Enter encrypted github token for appveyor:', function (appveyor) {
       init({travis, appveyor})
     })
   })
-} else if (process.argv[2] === 'download') {
-  download()
+} else if (argv._[0] === 'download') {
+  download(argv)
 } else {
   console.error('Usage: prebuildify-ci init|download')
   process.exit(1)
@@ -47,7 +48,7 @@ function init (opts) {
   }
 }
 
-function download () {
+function download (opts) {
   var file = path.resolve('./package.json')
   var repo = pkg(file)
   var v = require(file).version
@@ -62,11 +63,26 @@ function download () {
 
     var assets = doc.assets
 
+    if (!assets.length || !assets.every(uploaded)) {
+      console.log('Assets have not finished uploading. Try again after CI has finished')
+      process.exit(1)
+    }
+
     rimraf.sync('.prebuilds.tmp')
     fs.mkdir('.prebuilds.tmp', function () {
       loop()
 
       function done () {
+        if (opts.expect) {
+          var expected = opts.expect
+          var actual = fs.readdirSync('.prebuilds.tmp').length
+
+          if (actual !== expected) {
+            console.log('Expected %d platform-arch combinations, got %d', expected, actual)
+            process.exit(1)
+          }
+        }
+
         fs.rename('prebuilds', '.prebuilds.old.tmp', function () {
           fs.rename('.prebuilds.tmp', 'prebuilds', function (err) {
             if (err) throw err
@@ -100,6 +116,10 @@ function download () {
       }
     })
   })
+}
+
+function uploaded (asset) {
+  return asset.state === 'uploaded'
 }
 
 function travis (token) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "ghreleases": "^2.0.0",
     "gunzip-maybe": "^1.4.1",
+    "minimist": "^1.2.0",
     "package-repo": "^1.0.0",
     "request": "^2.85.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
When you have multiple jobs, failed jobs and/or multiple CI providers. Example:

```
cd leveldown
prebuildify-ci download --expect 8
Downloading prebuilds from Level/leveldown@5.0.0
Downloading v5.0.0-win32-x64.tar.gz
Downloading v5.0.0-linux-x64.tar.gz
Downloading v5.0.0-darwin-x64.tar.gz
Downloading v5.0.0-arm.tar.gz
Expected 8 platform-arch combinations, got 7
```